### PR TITLE
Update turbine.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [0.5.0]
+- AIRBRAKE_ROOT_DIRECTORY setting
+
 ## [0.4.0]
 - AIRBRAKE_IGNORE_ENVIRONMENTS setting
 - set root_directory to nil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project *loosely tries* to adhere to [Semantic Versioning](http://semver.or
 
 ## [0.5.0]
 - AIRBRAKE_ROOT_DIRECTORY setting
+- AIRBRAKE_ENVIRONMENT setting
 
 ## [0.4.0]
 - AIRBRAKE_IGNORE_ENVIRONMENTS setting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 PATH
   remote: .
   specs:
-    airbrake-jets (0.4.0)
+    airbrake-jets (0.5.0)
       airbrake-ruby
 
 GEM
   remote: https://rubygems.org/
   specs:
-    airbrake-ruby (3.2.3)
+    airbrake-ruby (6.1.1)
       rbtree3 (~> 0.5)
     diff-lcs (1.3)
     rake (10.5.0)
-    rbtree3 (0.5.0)
+    rbtree3 (0.7.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -36,4 +36,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.1
+   2.1.2

--- a/lib/airbrake_jets/turbine.rb
+++ b/lib/airbrake_jets/turbine.rb
@@ -6,7 +6,7 @@ module AirbrakeJets
       Airbrake.configure do |c|
         c.project_id = ENV["AIRBRAKE_PROJECT_ID"]
         c.project_key = ENV["AIRBRAKE_PROJECT_KEY"]
-        c.environment = Jets.env.to_s
+        c.environment = ENV["AIRBRAKE_ENVIRONMENT"] || Jets.env.to_s
         ignore_environments = ENV["AIRBRAKE_IGNORE_ENVIRONMENTS"]
         c.ignore_environments = ignore_environments ? ignore_environments.split(' ') : %w(test cucumber)
         c.root_directory = ENV["AIRBRAKE_ROOT_DIRECTORY"] # set to nil to bypass Airbrake::Filters

--- a/lib/airbrake_jets/turbine.rb
+++ b/lib/airbrake_jets/turbine.rb
@@ -9,7 +9,7 @@ module AirbrakeJets
         c.environment = Jets.env.to_s
         ignore_environments = ENV["AIRBRAKE_IGNORE_ENVIRONMENTS"]
         c.ignore_environments = ignore_environments ? ignore_environments.split(' ') : %w(test cucumber)
-        c.root_directory = nil # to bypass Airbrake::Filters
+        c.root_directory = ENV["AIRBRAKE_ROOT_DIRECTORY"] # set to nil to bypass Airbrake::Filters
       end
     end
 

--- a/lib/airbrake_jets/version.rb
+++ b/lib/airbrake_jets/version.rb
@@ -1,3 +1,3 @@
 module AirbrakeJets
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
Adds `ENV["AIRBRAKE_ROOT_DIRECTORY"]` so we can change the default `root_directory` and `ENV["AIRBRAKE_ENVIRONMENT"]` so we can change the `environment` option.